### PR TITLE
Breaking: swap env name and subcommand

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,7 +23,7 @@ tasks:
     deps:
       - install:base
     cmds:
-      - "{{.FLITENV}} test install"
+      - "{{.FLITENV}} install test"
   install:lint:
     sources:
       - pyproject.toml
@@ -32,7 +32,7 @@ tasks:
     deps:
       - install:base
     cmds:
-      - "{{.FLITENV}} lint install"
+      - "{{.FLITENV}} install lint"
 
   release:
     desc: generate and upload a new release
@@ -54,44 +54,44 @@ tasks:
     deps:
       - install:test
     cmds:
-      - "{{.FLITENV}} test run pytest {{.CLI_ARGS}}"
+      - "{{.FLITENV}} run test pytest {{.CLI_ARGS}}"
   flake8:
     desc: "lint Python code"
     deps:
       - install:lint
     cmds:
-      - "{{.FLITENV}} lint run flake8 {{.CLI_ARGS}} ."
+      - "{{.FLITENV}} run lint flake8 {{.CLI_ARGS}} ."
   ruff:
     desc: "lint Python code"
     deps:
       - install:lint
     cmds:
-      - "{{.FLITENV}} lint run ruff check {{.CLI_ARGS}} ."
+      - "{{.FLITENV}} run lint ruff check {{.CLI_ARGS}} ."
   ruff:fix:
     desc: "fix all possible ruff violations"
     deps:
       - install:lint
     cmds:
-      - "{{.FLITENV}} lint run ruff check --fix-only {{.CLI_ARGS}} ."
+      - "{{.FLITENV}} run lint ruff check --fix-only {{.CLI_ARGS}} ."
 
   mypy:
     desc: "check type annotations"
     deps:
       - install:lint
     cmds:
-      - "{{.FLITENV}} lint run mypy {{.CLI_ARGS}}"
+      - "{{.FLITENV}} run lint mypy {{.CLI_ARGS}}"
   isort:
     desc: "sort imports"
     deps:
       - install:lint
     cmds:
-      - "{{.FLITENV}} lint run isort {{.CLI_ARGS}} ."
+      - "{{.FLITENV}} run lint isort {{.CLI_ARGS}} ."
   isort:check:
     desc: "sort imports"
     deps:
       - install:lint
     cmds:
-      - "{{.FLITENV}} lint run isort --check {{.CLI_ARGS}} ."
+      - "{{.FLITENV}} run lint isort --check {{.CLI_ARGS}} ."
 
   # groups
   format:

--- a/flitenv/_venvs.py
+++ b/flitenv/_venvs.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import toml
+
+from ._constants import MAIN_ENV
+
+
+def get_envs() -> list[str] | None:
+    path = Path('pyproject.toml')
+    if not path.exists():
+        return None
+    with path.open('r', encoding='utf-8') as stream:
+        pyproject = toml.load(stream)
+    envs = _get_old_flit_extras(pyproject)
+    if envs is None:
+        envs = _get_new_extras(pyproject)
+    if envs is None:
+        return [MAIN_ENV]
+    return [MAIN_ENV, *sorted(envs)]
+
+
+def _get_old_flit_extras(pyproject: dict[str, Any]) -> dict[str, Any] | None:
+    try:
+        return pyproject['tool']['flit']['metadata']['requires-extra']
+    except KeyError:
+        return None
+
+
+def _get_new_extras(pyproject: dict[str, Any]) -> dict[str, Any] | None:
+    try:
+        return pyproject['project']['optional-dependencies']
+    except KeyError:
+        return None

--- a/flitenv/commands/__init__.py
+++ b/flitenv/commands/__init__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+
+from ._base import Command
+from ._install import Install
+from ._lock import Lock
+from ._run import Run
+from ._version import Version
+
+
+commands: MappingProxyType[str, type[Command]]
+commands = MappingProxyType({
+    'install': Install,
+    'lock': Lock,
+    'run': Run,
+    'version': Version,
+})
+
+__all__ = [
+    'commands',
+    'Command',
+]

--- a/flitenv/commands/_base.py
+++ b/flitenv/commands/_base.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser, Namespace
+from dataclasses import dataclass
+from functools import cached_property
+from pathlib import Path
+from typing import ClassVar, TextIO
+
+from .._deps_manager import DepsManager
+from .._venv import VEnv
+from .._venvs import get_envs
+
+
+@dataclass
+class Command:
+    name: ClassVar[str]
+    args: Namespace
+    stdout: TextIO
+
+    @staticmethod
+    def init_parser(parser: ArgumentParser) -> None:
+        parser.add_argument('env', choices=get_envs())
+        parser.add_argument('--venvs', type=Path)
+
+    def run(self) -> int:
+        raise NotImplementedError
+
+    def print(self, *args: str, end: str = '\n', sep: str = ' ') -> None:
+        print(*args, file=self.stdout, end=end, sep=sep)
+
+    @cached_property
+    def venv(self) -> VEnv:
+        return VEnv(
+            name=self.args.env,
+            root=self.args.root,
+            venvs=self.args.venvs,
+        )
+
+    @cached_property
+    def deps(self) -> DepsManager:
+        return DepsManager(
+            root=self.args.root,
+            venv=self.venv,
+            stream=self.stdout,
+        )

--- a/flitenv/commands/_install.py
+++ b/flitenv/commands/_install.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from ._base import Command
+
+
+class Install(Command):
+    """Install dependencies in the given environment.
+    """
+
+    def run(self) -> int:
+        return self.deps.install()

--- a/flitenv/commands/_lock.py
+++ b/flitenv/commands/_lock.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+from ._base import Command
+
+
+class Lock(Command):
+    """Generate lock file for the given environment.
+    """
+
+    @staticmethod
+    def init_parser(parser: ArgumentParser) -> None:
+        Command.init_parser(parser)
+        parser.add_argument('-c', '--constraint')
+
+    def run(self) -> int:
+        return self.deps.lock(constraint=self.args.constraint)

--- a/flitenv/commands/_run.py
+++ b/flitenv/commands/_run.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+from ._base import Command
+
+
+class Run(Command):
+    """Run a command in the given environment.
+    """
+
+    @staticmethod
+    def init_parser(parser: ArgumentParser) -> None:
+        Command.init_parser(parser)
+        parser.add_argument('exe')
+        parser.add_argument('args', nargs='...')
+
+    def run(self) -> int:
+        return self.deps.run(self.args.exe, *self.args.args)

--- a/flitenv/commands/_version.py
+++ b/flitenv/commands/_version.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+from ._base import Command
+
+
+class Version(Command):
+    """Print the version of flitenv.
+    """
+
+    @staticmethod
+    def init_parser(parser: ArgumentParser) -> None:
+        pass
+
+    def run(self) -> int:
+        from flitenv import __version__
+        self.print(__version__)
+        return 0

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8,22 +8,22 @@ from flitenv._cli import main
 
 
 def test_install_main(project: Path) -> None:
-    cmd = ['--root', str(project), 'main', 'install']
-    main(argv=cmd, stream=sys.stdout)
+    cmd = ['--root', str(project), 'install', 'main']
+    main(argv=cmd, stdout=sys.stdout)
     print(list(project.iterdir()))
     assert (project / '.venvs' / 'main' / 'bin').is_dir()
 
 
 def test_install_test(project: Path) -> None:
-    cmd = ['--root', str(project), 'test', 'install']
-    main(argv=cmd, stream=sys.stdout)
+    cmd = ['--root', str(project), 'install', 'test']
+    main(argv=cmd, stdout=sys.stdout)
     assert project.joinpath('.venvs', 'test', 'bin', 'pytest').exists()
 
 
 def test_install_test_with_lockfile(project: Path) -> None:
     (project / 'requirements.txt').write_text('pytest==6.2.1')
-    cmd = ['--root', str(project), 'test', 'install']
-    main(argv=cmd, stream=sys.stdout)
+    cmd = ['--root', str(project), 'install', 'test']
+    main(argv=cmd, stdout=sys.stdout)
     pytest_path = project.joinpath('.venvs', 'test', 'bin', 'pytest')
     assert pytest_path.exists()
     result = subprocess.run([str(pytest_path), '--version'], capture_output=True)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -7,8 +7,8 @@ from flitenv._cli import main
 
 
 def test_lock_main(project: Path) -> None:
-    cmd = ['--root', str(project), 'main', 'lock']
-    main(argv=cmd, stream=sys.stdout)
+    cmd = ['--root', str(project), 'lock', 'main']
+    main(argv=cmd, stdout=sys.stdout)
     print(list(project.iterdir()))
     path = project / 'requirements.txt'
     assert path.is_file()
@@ -18,8 +18,8 @@ def test_lock_main(project: Path) -> None:
 
 
 def test_lock_test(project: Path) -> None:
-    cmd = ['--root', str(project), 'test', 'lock']
-    main(argv=cmd, stream=sys.stdout)
+    cmd = ['--root', str(project), 'lock', 'test']
+    main(argv=cmd, stdout=sys.stdout)
     print(list(project.iterdir()))
     path = project / 'requirements-test.txt'
     assert path.is_file()


### PR DESCRIPTION
Not all subcommands need an environment. This PR swaps the environment name and the subcommand.

Before: `flitenv lint run flake8`

After: `flitenv run lint flake8`