### PR TITLE
Do not include extras in lock file

### DIFF
--- a/flitenv/_deps_manager.py
+++ b/flitenv/_deps_manager.py
@@ -160,6 +160,7 @@ class DepsManager:
             '--annotate',
             '--no-header',
             '--no-emit-index-url',
+            '--strip-extras',
             '--output-file', str(self._get_constraint()),
             'pyproject.toml',
         ]


### PR DESCRIPTION
When extras are included in lock file, it cannot be used as constraints file in pip.